### PR TITLE
swagger updates to address docs and sdk issues

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/2015-10-31/account.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2015-10-31/account.json
@@ -32,7 +32,12 @@
         },
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/ResourceGroupNameParameter"
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$",
+            "description": "The resource group name."
           },
           {
             "name": "automationAccountName",
@@ -88,7 +93,12 @@
         },
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/ResourceGroupNameParameter"
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$",
+            "description": "The resource group name."
           },
           {
             "name": "automationAccountName",
@@ -150,7 +160,12 @@
         },
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/ResourceGroupNameParameter"
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$",
+            "description": "The resource group name."
           },
           {
             "name": "automationAccountName",
@@ -197,7 +212,12 @@
         },
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/ResourceGroupNameParameter"
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$",
+            "description": "The resource group name."
           },
           {
             "name": "automationAccountName",
@@ -246,7 +266,12 @@
         },
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/ResourceGroupNameParameter"
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$",
+            "description": "The resource group name."
           },
           {
             "$ref": "./definitions.json#/parameters/SubscriptionIdParameter"
@@ -362,7 +387,12 @@
         },
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/ResourceGroupNameParameter"
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$",
+            "description": "The resource group name."
           },
           {
             "name": "automationAccountName",
@@ -421,7 +451,12 @@
         },
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/ResourceGroupNameParameter"
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$",
+            "description": "The resource group name."
           },
           {
             "name": "automationAccountName",

--- a/specification/automation/resource-manager/Microsoft.Automation/2015-10-31/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2015-10-31/definitions.json
@@ -3747,8 +3747,7 @@
       "required": true,
       "type": "string",
       "pattern": "^[-\\w\\._]+$",
-      "description": "The resource group name.",
-      "x-ms-parameter-location": "method"
+      "description": "The resource group name."
     }
   }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -247,26 +247,24 @@
             "type": "object",
             "description": "Windows specific update configuration.",
             "properties": {
-            "includedUpdateClassifications": {
-                "description": "Update classification included in the software update configuration.",
-                "items": {
-                "type": "integer",
-                "enum": [
-                    "Unclassified",
-                    "Critical",
-                    "Security",
-                    "UpdateRollup",
-                    "FeaturePack",
-                    "ServicePack",
-                    "Definition",
-                    "Tools",
-                    "Updates"
-                ],
-                "x-ms-enum": {
-                    "name": "WindowsUpdateClasses",
-                    "modelAsString": false
-                }
-                }
+                "includedUpdateClassifications": {
+                    "description": "Update classification included in the software update configuration.",
+                    "type": "integer",
+                    "enum": [
+                        "Unclassified",
+                        "Critical",
+                        "Security",
+                        "UpdateRollup",
+                        "FeaturePack",
+                        "ServicePack",
+                        "Definition",
+                        "Tools",
+                        "Updates"
+                    ],
+                    "x-ms-enum": {
+                        "name": "WindowsUpdateClasses",
+                        "modelAsString": false
+                    }
             },
             "excludedKbNumbers": {
                 "type": "array",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -243,41 +243,36 @@
             "required": [ "operatingSystem" ]
         },
 
-        "WindowsUpdateClasses": {
-            "type": "string",
-            "description": "Enumeration of the values used to set the includedUpdateClassifications property",
-            "enum": [
-                "Unclassified",
-                "Critical",
-                "Security",
-                "UpdateRollup",
-                "FeaturePack",
-                "ServicePack",
-                "Definition",
-                "Tools",
-                "Updates"
-            ],
-            "x-ms-enum": {
-                "name": "WindowsUpdateClasses",
-                "modelAsString": true
-            }
-        },
-
         "WindowsProperties": {
             "type": "object",
             "description": "Windows specific update configuration.",
             "properties": {
                 "includedUpdateClassifications": {
                     "description": "Update classification included in the software update configuration. This is a bitfield where multiple values can be used",
-                    "type": "integer"
-            },
-            "excludedKbNumbers": {
-                "type": "array",
-                "description": "KB numbers excluded from the software update configuration.",
-                "items": {
-                "type": "string"
+                    "type": "integer",
+                    "enum": [
+                        "Unclassified",
+                        "Critical",
+                        "Security",
+                        "UpdateRollup",
+                        "FeaturePack",
+                        "ServicePack",
+                        "Definition",
+                        "Tools",
+                        "Updates"
+                    ],
+                    "x-ms-enum": {
+                        "name": "WindowsUpdateClasses",
+                        "modelAsString": true
+                    }
+                },
+                "excludedKbNumbers": {
+                    "type": "array",
+                    "description": "KB numbers excluded from the software update configuration.",
+                    "items": {
+                        "type": "string"
+                    }
                 }
-            }
             }
         },
 

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -59,7 +59,7 @@
                     "readOnly": true
                 }
             },
-            "required": [ "updateConfiguration" ]
+            "required": [ "updateConfiguration", "scheduleInfo" ]
         },
 
         "softwareUpdateConfiguration": {

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -262,7 +262,7 @@
                     ],
                     "x-ms-enum": {
                         "name": "WindowsUpdateClasses",
-                        "modelAsString": true
+                        "modelAsString": false
                     }
                 },
                 "excludedKbNumbers": {

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -66,28 +66,28 @@
             "x-ms-azure-resource": true,
             "description": "Software update configuration properties.",
             "type": "object",
-          "properties": {
-            "name": {
-              "readOnly": true,
-              "type": "string",
-              "description": "Resource name."
-            },
-            "id": {
-              "readOnly": true,
-              "type": "string",
-              "description": "Resource Id."
-            },
-            "type": {
-              "readOnly": true,
-              "type": "string",
-              "description": "Resource type"
-            },
             "properties": {
-              "x-ms-client-flatten": true,
-              "description": "Software update configuration properties.",
-              "$ref": "#/definitions/softwareUpdateConfigurationProperties"
-            }
-          },
+                "name": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Resource name."
+                },
+                "id": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Resource Id."
+                },
+                "type": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Resource type"
+                },
+                "properties": {
+                    "x-ms-client-flatten": true,
+                    "description": "Software update configuration properties.",
+                    "$ref": "#/definitions/softwareUpdateConfigurationProperties"
+                }
+            },
             "required": [ "properties" ]
         },
 

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -281,19 +281,16 @@
             "properties": {
             "includedPackageClassifications": {
                 "description": "Update classifications included in the software update configuration.",
-                "type": "array",
-                "items": {
                 "type": "string",
                 "enum": [
                     "Unclassified",
                     "Critical",
                     "Security",
                     "Other"
-                ]
-                },
+                ],
                 "x-ms-enum": {
-                "name": "LinuxUpdateClasses",
-                "modelAsString": true
+                    "name": "LinuxUpdateClasses",
+                    "modelAsString": true
                 }
             },
             "excludedPackageNameMasks": {

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -1,18 +1,18 @@
 {
     "swagger": "2.0",
     "info": {
-      "title": "AutomationManagement",
-      "version": "2015-10-31"
+        "title": "AutomationManagement",
+        "version": "2015-10-31"
     },
     "host": "management.azure.com",
     "schemes": [
-      "https"
+        "https"
     ],
     "consumes": [
-      "application/json"
+        "application/json"
     ],
     "produces": [
-      "application/json"
+        "application/json"
     ],
     "paths": {},
     "definitions": {
@@ -20,7 +20,7 @@
             "description": "Software update configuration properties.",
             "properties": {
                 "updateConfiguration": {
-                    "description":  "update specific properties for the Software update configuration",
+                    "description": "update specific properties for the Software update configuration",
                     "$ref": "#/definitions/updateConfiguration"
                 },
                 "scheduleInfo": {
@@ -59,9 +59,11 @@
                     "readOnly": true
                 }
             },
-            "required": [ "updateConfiguration", "scheduleInfo" ]
+            "required": [
+                "updateConfiguration",
+                "scheduleInfo"
+            ]
         },
-
         "softwareUpdateConfiguration": {
             "x-ms-azure-resource": true,
             "description": "Software update configuration properties.",
@@ -88,9 +90,10 @@
                     "$ref": "#/definitions/softwareUpdateConfigurationProperties"
                 }
             },
-            "required": [ "properties" ]
+            "required": [
+                "properties"
+            ]
         },
-
         "softwareUpdateConfigurationListResult": {
             "description": "result of listing all software update configuration",
             "properties": {
@@ -103,7 +106,6 @@
                 }
             }
         },
-
         "collectionItemUpdateConfiguration": {
             "description": "object returned when requesting a collection of software update configuration",
             "properties": {
@@ -111,8 +113,8 @@
                     "type": "array",
                     "description": "List of azure resource Ids for azure virtual machines targeted by the software update configuration.",
                     "items": {
-                    "type": "string",
-                    "description": "Azure Resource Manager Id for a virtual machine."
+                        "type": "string",
+                        "description": "Azure Resource Manager Id for a virtual machine."
                     }
                 },
                 "duration": {
@@ -122,30 +124,30 @@
                 }
             }
         },
-
         "softwareUpdateConfigurationCollectionItem": {
             "description": "Software update configuration collection item properties.",
             "type": "object",
             "properties": {
-            "name": {
-                "readOnly": true,
-                "type": "string",
-                "description": "Name of the software update configuration."
+                "name": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Name of the software update configuration."
+                },
+                "id": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Resource Id of the software update configuration"
+                },
+                "properties": {
+                    "x-ms-client-flatten": true,
+                    "description": "Software update configuration properties.",
+                    "$ref": "#/definitions/softwareUpdateConfigurationCollectionItemProperties"
+                }
             },
-            "id": {
-                "readOnly": true,
-                "type": "string",
-                "description": "Resource Id of the software update configuration"
-            },
-            "properties": {
-                "x-ms-client-flatten": true,
-                "description": "Software update configuration properties.",
-                "$ref": "#/definitions/softwareUpdateConfigurationCollectionItemProperties"
-            }
-            },
-            "required": [ "properties" ]
+            "required": [
+                "properties"
+            ]
         },
-
         "softwareUpdateConfigurationCollectionItemProperties": {
             "description": "Software update configuration collection item properties.",
             "properties": {
@@ -155,7 +157,7 @@
                 },
                 "frequency": {
                     "description": "execution frequency of the schedule associated with the software update configuration",
-                    "type":"string",
+                    "type": "string",
                     "$ref": "../2015-10-31/definitions.json#/definitions/scheduleFrequency"
                 },
                 "startTime": {
@@ -187,7 +189,6 @@
                 }
             }
         },
-
         "operatingSystemType": {
             "type": "string",
             "description": "Target operating system for the software update configuration.",
@@ -200,7 +201,6 @@
                 "name": "OperatingSystemType"
             }
         },
-
         "updateConfiguration": {
             "type": "object",
             "description": "Update specifc properties of the software update configuration.",
@@ -226,22 +226,23 @@
                     "type": "array",
                     "description": "List of azure resource Ids for azure virtual machines targeted by the software update configuration.",
                     "items": {
-                    "type": "string",
-                    "description": "Azure Resource Manager Id for a virtual machine."
+                        "type": "string",
+                        "description": "Azure Resource Manager Id for a virtual machine."
                     }
                 },
                 "nonAzureComputerNames": {
                     "type": "array",
                     "description": "List of names of non-azure machines targeted by the software update configuration.",
                     "items": {
-                    "type": "string",
-                    "description": "Name of Non-Azure OMS Computer."
+                        "type": "string",
+                        "description": "Name of Non-Azure OMS Computer."
                     }
                 }
             },
-            "required": [ "operatingSystem" ]
+            "required": [
+                "operatingSystem"
+            ]
         },
-
         "WindowsProperties": {
             "type": "object",
             "description": "Windows specific update configuration.",
@@ -274,59 +275,55 @@
                 }
             }
         },
-
         "LinuxProperties": {
             "type": "object",
             "description": "Linux specific update configuration.",
             "properties": {
-            "includedPackageClassifications": {
-                "description": "Update classifications included in the software update configuration.",
-                "type": "string",
-                "enum": [
-                    "Unclassified",
-                    "Critical",
-                    "Security",
-                    "Other"
-                ],
-                "x-ms-enum": {
-                    "name": "LinuxUpdateClasses",
-                    "modelAsString": true
+                "includedPackageClassifications": {
+                    "description": "Update classifications included in the software update configuration.",
+                    "type": "string",
+                    "enum": [
+                        "Unclassified",
+                        "Critical",
+                        "Security",
+                        "Other"
+                    ],
+                    "x-ms-enum": {
+                        "name": "LinuxUpdateClasses",
+                        "modelAsString": true
+                    }
+                },
+                "excludedPackageNameMasks": {
+                    "type": "array",
+                    "description": "packages excluded from the software update configuration.",
+                    "items": {
+                        "type": "string"
+                    }
                 }
-            },
-            "excludedPackageNameMasks": {
-                "type": "array",
-                "description": "packages excluded from the software update configuration.",
-                "items": {
-                "type": "string"
-                }
-            }
             }
         },
-
         "updateConfigurationNavigation": {
             "description": "Software update configuration Run Navigation model.",
             "type": "object",
             "properties": {
-            "name": {
-                "description": "Name of the software update configuration triggered the software update configuration run",
-                "type": "string",
-                "readOnly": true
-            }
+                "name": {
+                    "description": "Name of the software update configuration triggered the software update configuration run",
+                    "type": "string",
+                    "readOnly": true
+                }
             }
         },
-
         "jobNavigation": {
             "description": "Software update configuration machine run job navigation properties.",
             "type": "object",
             "properties": {
-            "id": {
-                "description": "Id of the job associated with the software update configuration run",
-                "type": "string",
-                "readOnly": true
-            }
+                "id": {
+                    "description": "Id of the job associated with the software update configuration run",
+                    "type": "string",
+                    "readOnly": true
+                }
             }
         },
-
         "softwareUpdateConfigurationRunListResult": {
             "description": "result of listing all software update configuration runs",
             "properties": {
@@ -343,7 +340,6 @@
                 }
             }
         },
-
         "softwareUpdateConfigurationRun": {
             "description": "Software update configuration Run properties.",
             "x-ms-azure-resource": false,
@@ -366,7 +362,6 @@
                 }
             }
         },
-
         "softwareUpdateConfigurationRunProperties": {
             "description": "Software update configuration properties.",
             "properties": {
@@ -435,7 +430,6 @@
                 }
             }
         },
-
         "softwareUpdateConfigurationMachineRunListResult": {
             "description": "result of listing all software update configuration machine runs",
             "properties": {
@@ -452,7 +446,6 @@
                 }
             }
         },
-
         "updateConfigurationMachineRunProperties": {
             "description": "Software update configuration machine run properties.",
             "properties": {
@@ -562,18 +555,18 @@
     },
     "parameters": {
         "automationAccountName": {
-          "name": "automationAccountName",
-          "description": "The name of the automation account.",
-          "type": "string",
-          "required": true,
-          "in": "path"
+            "name": "automationAccountName",
+            "description": "The name of the automation account.",
+            "type": "string",
+            "required": true,
+            "in": "path"
         },
         "clientRequestId": {
-          "name": "clientRequestId",
-          "description": "Identifies this specific client request.",
-          "type": "string",
-          "required": false,
-          "in": "header"
+            "name": "clientRequestId",
+            "description": "Identifies this specific client request.",
+            "type": "string",
+            "required": false,
+            "in": "header"
         }
     }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -248,7 +248,7 @@
             "description": "Windows specific update configuration.",
             "properties": {
                 "includedUpdateClassifications": {
-                    "description": "Update classification included in the software update configuration.",
+                    "description": "Update classification included in the software update configuration. This is a bitfield where multiple values can be used",
                     "type": "integer",
                     "enum": [
                         "Unclassified",
@@ -263,7 +263,7 @@
                     ],
                     "x-ms-enum": {
                         "name": "WindowsUpdateClasses",
-                        "modelAsString": false
+                        "modelAsString": true
                     }
             },
             "excludedKbNumbers": {

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -243,28 +243,33 @@
             "required": [ "operatingSystem" ]
         },
 
+        "WindowsUpdateClasses": {
+            "type": "string",
+            "description": "Enumeration of the values used to set the includedUpdateClassifications property",
+            "enum": [
+                "Unclassified",
+                "Critical",
+                "Security",
+                "UpdateRollup",
+                "FeaturePack",
+                "ServicePack",
+                "Definition",
+                "Tools",
+                "Updates"
+            ],
+            "x-ms-enum": {
+                "name": "WindowsUpdateClasses",
+                "modelAsString": true
+            }
+        },
+
         "WindowsProperties": {
             "type": "object",
             "description": "Windows specific update configuration.",
             "properties": {
                 "includedUpdateClassifications": {
                     "description": "Update classification included in the software update configuration. This is a bitfield where multiple values can be used",
-                    "type": "string",
-                    "enum": [
-                        "Unclassified",
-                        "Critical",
-                        "Security",
-                        "UpdateRollup",
-                        "FeaturePack",
-                        "ServicePack",
-                        "Definition",
-                        "Tools",
-                        "Updates"
-                    ],
-                    "x-ms-enum": {
-                        "name": "WindowsUpdateClasses",
-                        "modelAsString": true
-                    }
+                    "type": "integer"
             },
             "excludedKbNumbers": {
                 "type": "array",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -250,7 +250,7 @@
             "includedUpdateClassifications": {
                 "description": "Update classification included in the software update configuration.",
                 "items": {
-                "type": "string",
+                "type": "integer",
                 "enum": [
                     "Unclassified",
                     "Critical",
@@ -264,7 +264,7 @@
                 ],
                 "x-ms-enum": {
                     "name": "WindowsUpdateClasses",
-                    "modelAsString": true
+                    "modelAsString": false
                 }
                 }
             },

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -586,29 +586,6 @@
           "required": true,
           "in": "path"
         },
-        "softwareUpdateConfigurationName": {
-          "name": "softwareUpdateConfigurationName",
-          "description": "The name of the software update configuration to be created.",
-          "type": "string",
-          "required": true,
-          "in": "path"
-        },
-        "softwareUpdateConfigurationRunId": {
-          "name": "softwareUpdateConfigurationRunId",
-          "description": "The Id of the software update configuration run.",
-          "type": "string",
-          "required": true,
-          "in": "path",
-          "format": "uuid"
-        },
-        "softwareUpdateConfigurationMachineRunId": {
-          "name": "softwareUpdateConfigurationMachineRunId",
-          "description": "The Id of the software update configuration machine run.",
-          "type": "string",
-          "required": true,
-          "in": "path",
-          "format": "uuid"
-        },
         "apiVersion": {
           "name": "api-version",
           "description": "The API version.",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -561,34 +561,12 @@
         }
     },
     "parameters": {
-        "subscriptionId": {
-          "name": "subscriptionId",
-          "description": "subscription id for tenant issuing the request.",
-          "type": "string",
-          "required": true,
-          "in": "path",
-          "format": "uuid"
-        },
-        "resourceGroupName": {
-          "name": "resourceGroupName",
-          "description": "The name of the resource group within user's subscription.",
-          "type": "string",
-          "required": true,
-          "in": "path"
-        },
         "automationAccountName": {
           "name": "automationAccountName",
           "description": "The name of the automation account.",
           "type": "string",
           "required": true,
           "in": "path"
-        },
-        "apiVersion": {
-          "name": "api-version",
-          "description": "The API version.",
-          "type": "string",
-          "required": true,
-          "in": "query"
         },
         "clientRequestId": {
           "name": "clientRequestId",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -249,7 +249,7 @@
             "properties": {
                 "includedUpdateClassifications": {
                     "description": "Update classification included in the software update configuration. This is a bitfield where multiple values can be used",
-                    "type": "integer",
+                    "type": "string",
                     "enum": [
                         "Unclassified",
                         "Critical",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -247,8 +247,8 @@
             "description": "Windows specific update configuration.",
             "properties": {
                 "includedUpdateClassifications": {
-                    "description": "Update classification included in the software update configuration. This is a bitfield where multiple values can be used",
-                    "type": "integer",
+                    "description": "Update classification included in the software update configuration. A comma separated string with required values",
+                    "type": "string",
                     "enum": [
                         "Unclassified",
                         "Critical",
@@ -262,7 +262,7 @@
                     ],
                     "x-ms-enum": {
                         "name": "WindowsUpdateClasses",
-                        "modelAsString": false
+                        "modelAsString": true
                     }
                 },
                 "excludedKbNumbers": {

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -585,8 +585,7 @@
           "description": "The name of the automation account.",
           "type": "string",
           "required": true,
-          "in": "path",
-          "format": "uuid"
+          "in": "path"
         },
         "softwareUpdateConfigurationName": {
           "name": "softwareUpdateConfigurationName",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/definitions.json
@@ -204,7 +204,6 @@
         "updateConfiguration": {
             "type": "object",
             "description": "Update specifc properties of the software update configuration.",
-            "discriminator": "operatingSystem",
             "properties": {
                 "operatingSystem": {
                     "description": "operating system of target machines",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
@@ -59,6 +59,9 @@
             "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
           },
           {
+            "$ref": "./definitions.json#/parameters/automationAccountName"
+          },
+          {
             "name": "softwareUpdateConfigurationName",
             "description": "The name of the software update configuration to be created.",
             "type": "string",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
@@ -41,14 +41,6 @@
 
   "paths": {
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurations/{softwareUpdateConfigurationName}": {
-      "parameters":[
-        {
-          "$ref": "./definitions.json#/parameters/subscriptionId"
-        },
-        {
-          "$ref": "./definitions.json#/parameters/resourceGroupName"
-        }
-      ],
       "put": {
         "tags": [ "Software Update Configuration" ],
         "description": "Create a new software update configuration with the name given in the URI.",
@@ -61,6 +53,12 @@
         "operationId": "SoftwareUpdateConfigurations_Create",
         "parameters": [
           {
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
             "name": "softwareUpdateConfigurationName",
             "description": "The name of the software update configuration to be created.",
             "type": "string",
@@ -68,7 +66,7 @@
             "in": "path"
           },
           {
-            "$ref": "./definitions.json#/parameters/apiVersion"
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
           },
           {
             "$ref": "./definitions.json#/parameters/clientRequestId"
@@ -121,10 +119,10 @@
         "operationId": "SoftwareUpdateConfigurations_GetByName",
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/subscriptionId"
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "./definitions.json#/parameters/resourceGroupName"
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "$ref": "./definitions.json#/parameters/automationAccountName"
@@ -137,7 +135,7 @@
             "in": "path"
           },
           {
-            "$ref": "./definitions.json#/parameters/apiVersion"
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
           },
           {
             "$ref": "./definitions.json#/parameters/clientRequestId"
@@ -168,10 +166,10 @@
         "operationId": "SoftwareUpdateConfigurations_Delete",
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/subscriptionId"
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "./definitions.json#/parameters/resourceGroupName"
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "$ref": "./definitions.json#/parameters/automationAccountName"
@@ -184,7 +182,7 @@
             "in": "path"
           },
           {
-            "$ref": "./definitions.json#/parameters/apiVersion"
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
           },
           {
             "$ref": "./definitions.json#/parameters/clientRequestId"
@@ -218,16 +216,16 @@
         "operationId": "SoftwareUpdateConfigurations_List",
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/subscriptionId"
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "./definitions.json#/parameters/resourceGroupName"
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "$ref": "./definitions.json#/parameters/automationAccountName"
           },
           {
-            "$ref": "./definitions.json#/parameters/apiVersion"
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
           },
           {
             "$ref": "./definitions.json#/parameters/clientRequestId"

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
@@ -41,6 +41,14 @@
 
   "paths": {
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurations/{softwareUpdateConfigurationName}": {
+      "parameters":[
+        {
+          "$ref": "./definitions.json#/parameters/subscriptionId"
+        },
+        {
+          "$ref": "./definitions.json#/parameters/resourceGroupName"
+        }
+      ],
       "put": {
         "tags": [ "Software Update Configuration" ],
         "description": "Create a new software update configuration with the name given in the URI.",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
@@ -1,6 +1,5 @@
 {
   "swagger": "2.0",
-
   "info": {
     "title": "Update Management API",
     "description": "APIs for managing software update configurations.",
@@ -9,17 +8,17 @@
     },
     "version": "2017-05-15-preview"
   },
-
-  "consumes": [ "application/json" ],
-
-  "produces": [ "application/json" ],
-
-  "schemes": [ "https" ],
-
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
   "host": "management.azure.com",
-
   "basePath": "/",
-
   "security": [
     {
       "azure_auth": [
@@ -38,17 +37,20 @@
       }
     }
   },
-
   "paths": {
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurations/{softwareUpdateConfigurationName}": {
       "put": {
-        "tags": [ "Software Update Configuration" ],
+        "tags": [
+          "Software Update Configuration"
+        ],
         "description": "Create a new software update configuration with the name given in the URI.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
         },
         "x-ms-examples": {
-          "Create software update configuration": { "$ref": "./examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json" }
+          "Create software update configuration": {
+            "$ref": "./examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json"
+          }
         },
         "operationId": "SoftwareUpdateConfigurations_Create",
         "parameters": [
@@ -108,16 +110,18 @@
           }
         }
       },
-
-
       "get": {
-        "tags": [ "Software Update Configuration" ],
+        "tags": [
+          "Software Update Configuration"
+        ],
         "description": "Get a single software update configuration by name.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
         },
         "x-ms-examples": {
-          "Get software update configuration by name": { "$ref": "./examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json" }
+          "Get software update configuration by name": {
+            "$ref": "./examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json"
+          }
         },
         "operationId": "SoftwareUpdateConfigurations_GetByName",
         "parameters": [
@@ -156,15 +160,18 @@
           }
         }
       },
-
       "delete": {
-        "tags": [ "Software Update Configuration" ],
+        "tags": [
+          "Software Update Configuration"
+        ],
         "description": "delete a specific software update configuration.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
         },
         "x-ms-examples": {
-          "Delete software update configuration": { "$ref": "./examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json" }
+          "Delete software update configuration": {
+            "$ref": "./examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json"
+          }
         },
         "operationId": "SoftwareUpdateConfigurations_Delete",
         "parameters": [
@@ -204,17 +211,22 @@
         }
       }
     },
-
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurations": {
       "get": {
-        "tags": [ "Software Update Configuration" ],
+        "tags": [
+          "Software Update Configuration"
+        ],
         "description": "Get all software update configurations for the account.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
         },
         "x-ms-examples": {
-          "List software update configurations": { "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json" },
-          "List software update configurations Targeting a specific azure virtual machine": { "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json" }
+          "List software update configurations": {
+            "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json"
+          },
+          "List software update configurations Targeting a specific azure virtual machine": {
+            "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json"
+          }
         },
         "operationId": "SoftwareUpdateConfigurations_List",
         "parameters": [
@@ -254,5 +266,5 @@
         }
       }
     }
-  }  
+  }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
@@ -53,15 +53,6 @@
         "operationId": "SoftwareUpdateConfigurations_Create",
         "parameters": [
           {
-            "$ref": "./definitions.json#/parameters/subscriptionId"
-          },
-          {
-            "$ref": "./definitions.json#/parameters/resourceGroupName"
-          },
-          {
-            "$ref": "./definitions.json#/parameters/automationAccountName"
-          },
-          {
             "name": "softwareUpdateConfigurationName",
             "description": "The name of the software update configuration to be created.",
             "type": "string",

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
@@ -50,7 +50,7 @@
         "x-ms-examples": {
           "Create software update configuration": { "$ref": "./examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json" }
         },
-        "operationId": "softwareUpdateConfigurations_Create",
+        "operationId": "SoftwareUpdateConfigurations_Create",
         "parameters": [
           {
             "$ref": "./definitions.json#/parameters/subscriptionId"
@@ -119,7 +119,7 @@
         "x-ms-examples": {
           "Get software update configuration by name": { "$ref": "./examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json" }
         },
-        "operationId": "softwareUpdateConfigurations_GetByName",
+        "operationId": "SoftwareUpdateConfigurations_GetByName",
         "parameters": [
           {
             "$ref": "./definitions.json#/parameters/subscriptionId"
@@ -131,7 +131,11 @@
             "$ref": "./definitions.json#/parameters/automationAccountName"
           },
           {
-            "$ref": "./definitions.json#/parameters/softwareUpdateConfigurationName"
+            "name": "softwareUpdateConfigurationName",
+            "description": "The name of the software update configuration to be created.",
+            "type": "string",
+            "required": true,
+            "in": "path"
           },
           {
             "$ref": "./definitions.json#/parameters/apiVersion"
@@ -162,7 +166,7 @@
         "x-ms-examples": {
           "Delete software update configuration": { "$ref": "./examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json" }
         },
-        "operationId": "softwareUpdateConfigurations_Delete",
+        "operationId": "SoftwareUpdateConfigurations_Delete",
         "parameters": [
           {
             "$ref": "./definitions.json#/parameters/subscriptionId"
@@ -174,7 +178,11 @@
             "$ref": "./definitions.json#/parameters/automationAccountName"
           },
           {
-            "$ref": "./definitions.json#/parameters/softwareUpdateConfigurationName"
+            "name": "softwareUpdateConfigurationName",
+            "description": "The name of the software update configuration to be created.",
+            "type": "string",
+            "required": true,
+            "in": "path"
           },
           {
             "$ref": "./definitions.json#/parameters/apiVersion"
@@ -208,7 +216,7 @@
           "List software update configurations": { "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json" },
           "List software update configurations Targeting a specific azure virtual machine": { "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json" }
         },
-        "operationId": "softwareUpdateConfigurations_List",
+        "operationId": "SoftwareUpdateConfigurations_List",
         "parameters": [
           {
             "$ref": "./definitions.json#/parameters/subscriptionId"

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfiguration.json
@@ -62,7 +62,11 @@
             "$ref": "./definitions.json#/parameters/automationAccountName"
           },
           {
-            "$ref": "./definitions.json#/parameters/softwareUpdateConfigurationName"
+            "name": "softwareUpdateConfigurationName",
+            "description": "The name of the software update configuration to be created.",
+            "type": "string",
+            "required": true,
+            "in": "path"
           },
           {
             "$ref": "./definitions.json#/parameters/apiVersion"

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
@@ -53,10 +53,10 @@
           "operationId": "SoftwareUpdateConfigurationMachineRuns_GetById",
           "parameters": [
             {
-              "$ref": "./definitions.json#/parameters/subscriptionId"
+              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
             },
             {
-              "$ref": "./definitions.json#/parameters/resourceGroupName"
+                "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
             },
             {
               "$ref": "./definitions.json#/parameters/automationAccountName"
@@ -70,7 +70,7 @@
               "format": "uuid"
             },
             {
-              "$ref": "./definitions.json#/parameters/apiVersion"
+              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
             },
             {
               "$ref": "./definitions.json#/parameters/clientRequestId"
@@ -105,17 +105,17 @@
           "operationId": "SoftwareUpdateConfigurationMachineRuns_List",
           "parameters": [
             {
-              "$ref": "./definitions.json#/parameters/subscriptionId"
+              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
             },
             {
-              "$ref": "./definitions.json#/parameters/resourceGroupName"
+                "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
             },
             {
               "$ref": "./definitions.json#/parameters/automationAccountName"
             },
             {
-              "$ref": "./definitions.json#/parameters/apiVersion"
-            },
+              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          },
             {
               "$ref": "./definitions.json#/parameters/clientRequestId"
             },

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
@@ -120,6 +120,13 @@
               "$ref": "./definitions.json#/parameters/clientRequestId"
             },
             {
+              "name": "$filter",
+              "in": "query",
+              "required": false,
+              "type": "string",
+              "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+            },
+            {
               "name": "$skip",
               "in": "query",
               "required": false,
@@ -132,13 +139,6 @@
               "required": false,
               "type": "string",
               "description": "Maximum number of entries returned in the results collection"
-            },
-            {
-              "name": "$filter",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
             }
           ],
           "responses": {

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
@@ -1,158 +1,164 @@
 {
-    "swagger": "2.0",
-  
-    "info": {
-      "title": "Update Management API",
-      "description": "APIs for managing software update configurations.",
-      "contact": {
-        "name": "Mohamed Enein"
-      },
-      "version": "2017-05-15-preview"
+  "swagger": "2.0",
+  "info": {
+    "title": "Update Management API",
+    "description": "APIs for managing software update configurations.",
+    "contact": {
+      "name": "Mohamed Enein"
     },
-  
-    "consumes": [ "application/json" ],
-  
-    "produces": [ "application/json" ],
-  
-    "schemes": [ "https" ],
-  
-    "host": "management.azure.com",
-  
-    "basePath": "/",
-  
-    "security": [
-      {
-        "azure_auth": [
-          "user_impersonation"
-        ]
+    "version": "2017-05-15-preview"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "basePath": "/",
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
       }
-    ],
-    "securityDefinitions": {
-      "azure_auth": {
-        "type": "oauth2",
-        "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
-        "flow": "implicit",
-        "description": "Azure Active Directory OAuth2 Flow",
-        "scopes": {
-          "user_impersonation": "impersonate your user account"
-        }
-      }
-    },
-  
-    "paths": {
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationMachineRuns/{softwareUpdateConfigurationMachineRunId}": {
-        "get": {
-          "tags": [ "Software Update Configuration Machine Run" ],
-          "description": "Get a single software update configuration machine run by Id.",
-          "externalDocs": {
-            "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
-          },
-          "x-ms-examples": {
-            "Get software update configuration machine run": { "$ref": "./examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json" }
-          },
-          "operationId": "SoftwareUpdateConfigurationMachineRuns_GetById",
-          "parameters": [
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
-            },
-            {
-                "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
-            },
-            {
-              "$ref": "./definitions.json#/parameters/automationAccountName"
-            },
-            {
-              "name": "softwareUpdateConfigurationMachineRunId",
-              "description": "The Id of the software update configuration machine run.",
-              "type": "string",
-              "required": true,
-              "in": "path",
-              "format": "uuid"
-            },
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
-            },
-            {
-              "$ref": "./definitions.json#/parameters/clientRequestId"
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "A single software update configuration machine run.",
-              "schema": {
-                "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationMachineRun"
-              }
-            },
-            "404": {
-              "description": "Resource group, account, or software update configuration machine run doesn't exist."
-            }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationMachineRuns/{softwareUpdateConfigurationMachineRunId}": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Machine Run"
+        ],
+        "description": "Get a single software update configuration machine run by Id.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "Get software update configuration machine run": {
+            "$ref": "./examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json"
           }
-        }
-      },
-  
-  
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationMachineRuns": {
-        "get": {
-          "tags": [ "Software Update Configuration Machine Run" ],
-          "description": "Return list of software update configuration machine runs",
-          "externalDocs": {
-            "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "operationId": "SoftwareUpdateConfigurationMachineRuns_GetById",
+        "parameters": [
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
           },
-          "x-ms-examples": {
-            "List software update configuration machine runs": { "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json" },
-            "List software update configuration machine runs for a specific software update configuration run": { "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json" }
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
           },
-          "operationId": "SoftwareUpdateConfigurationMachineRuns_List",
-          "parameters": [
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
-            },
-            {
-                "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
-            },
-            {
-              "$ref": "./definitions.json#/parameters/automationAccountName"
-            },
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          {
+            "$ref": "./definitions.json#/parameters/automationAccountName"
           },
-            {
-              "$ref": "./definitions.json#/parameters/clientRequestId"
-            },
-            {
-              "name": "$filter",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
-            },
-            {
-              "name": "$skip",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "number of entries you skip before returning results"
-            },
-            {
-              "name": "$top",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "Maximum number of entries returned in the results collection"
+          {
+            "name": "softwareUpdateConfigurationMachineRunId",
+            "description": "The Id of the software update configuration machine run.",
+            "type": "string",
+            "required": true,
+            "in": "path",
+            "format": "uuid"
+          },
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./definitions.json#/parameters/clientRequestId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single software update configuration machine run.",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationMachineRun"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "Return list of software update configuration machine runs.",
-              "schema": {
-                  "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationMachineRunListResult"
-              }
-            },
-            "404": {
-              "description": "Resource group, or account doesn't exist."
-            }
+          },
+          "404": {
+            "description": "Resource group, account, or software update configuration machine run doesn't exist."
           }
         }
       }
-    }  
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationMachineRuns": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Machine Run"
+        ],
+        "description": "Return list of software update configuration machine runs",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "List software update configuration machine runs": {
+            "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json"
+          },
+          "List software update configuration machine runs for a specific software update configuration run": {
+            "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurationMachineRuns_List",
+        "parameters": [
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "./definitions.json#/parameters/automationAccountName"
+          },
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./definitions.json#/parameters/clientRequestId"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "number of entries you skip before returning results"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Maximum number of entries returned in the results collection"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return list of software update configuration machine runs.",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationMachineRunListResult"
+            }
+          },
+          "404": {
+            "description": "Resource group, or account doesn't exist."
+          }
+        }
+      }
+    }
+  }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
@@ -50,7 +50,7 @@
           "x-ms-examples": {
             "Get software update configuration machine run": { "$ref": "./examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json" }
           },
-          "operationId": "softwareUpdateConfigurationMachineRuns_GetById",
+          "operationId": "SoftwareUpdateConfigurationMachineRuns_GetById",
           "parameters": [
             {
               "$ref": "./definitions.json#/parameters/subscriptionId"
@@ -62,7 +62,12 @@
               "$ref": "./definitions.json#/parameters/automationAccountName"
             },
             {
-              "$ref": "./definitions.json#/parameters/softwareUpdateConfigurationMachineRunId"
+              "name": "softwareUpdateConfigurationMachineRunId",
+              "description": "The Id of the software update configuration machine run.",
+              "type": "string",
+              "required": true,
+              "in": "path",
+              "format": "uuid"
             },
             {
               "$ref": "./definitions.json#/parameters/apiVersion"
@@ -97,7 +102,7 @@
             "List software update configuration machine runs": { "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json" },
             "List software update configuration machine runs for a specific software update configuration run": { "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json" }
           },
-          "operationId": "softwareUpdateConfigurationMachineRuns_List",
+          "operationId": "SoftwareUpdateConfigurationMachineRuns_List",
           "parameters": [
             {
               "$ref": "./definitions.json#/parameters/subscriptionId"

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
@@ -1,157 +1,164 @@
 {
-    "swagger": "2.0",
-  
-    "info": {
-      "title": "Update Management API",
-      "description": "APIs for managing software update configurations.",
-      "contact": {
-        "name": "Mohamed Enein"
-      },
-      "version": "2017-05-15-preview"
+  "swagger": "2.0",
+  "info": {
+    "title": "Update Management API",
+    "description": "APIs for managing software update configurations.",
+    "contact": {
+      "name": "Mohamed Enein"
     },
-  
-    "consumes": [ "application/json" ],
-  
-    "produces": [ "application/json" ],
-  
-    "schemes": [ "https" ],
-  
-    "host": "management.azure.com",
-  
-    "basePath": "/",
-  
-    "security": [
-      {
-        "azure_auth": [
-          "user_impersonation"
-        ]
+    "version": "2017-05-15-preview"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "basePath": "/",
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
       }
-    ],
-    "securityDefinitions": {
-      "azure_auth": {
-        "type": "oauth2",
-        "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
-        "flow": "implicit",
-        "description": "Azure Active Directory OAuth2 Flow",
-        "scopes": {
-          "user_impersonation": "impersonate your user account"
-        }
-      }
-    },
-  
-    "paths": {
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationRuns/{softwareUpdateConfigurationRunId}": {
-        "get": {
-          "tags": [ "Software Update Configuration Run" ],
-          "description": "Get a single software update configuration Run by Id.",
-          "externalDocs": {
-            "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationrunoperations"
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationRuns/{softwareUpdateConfigurationRunId}": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Run"
+        ],
+        "description": "Get a single software update configuration Run by Id.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationrunoperations"
+        },
+        "x-ms-examples": {
+          "Get software update configuration runs by Id": {
+            "$ref": "./examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurationRuns_GetById",
+        "parameters": [
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
           },
-          "x-ms-examples": {
-            "Get software update configuration runs by Id": { "$ref": "./examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json" }
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
           },
-          "operationId": "SoftwareUpdateConfigurationRuns_GetById",
-          "parameters": [
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
-            },
-            {
-                "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
-            },
-            {
-              "$ref": "./definitions.json#/parameters/automationAccountName"
-            },
-            {
-              "name": "softwareUpdateConfigurationRunId",
-              "description": "The Id of the software update configuration run.",
-              "type": "string",
-              "required": true,
-              "in": "path",
-              "format": "uuid"
-            },
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
-            },
-            {
-              "$ref": "./definitions.json#/parameters/clientRequestId"
+          {
+            "$ref": "./definitions.json#/parameters/automationAccountName"
+          },
+          {
+            "name": "softwareUpdateConfigurationRunId",
+            "description": "The Id of the software update configuration run.",
+            "type": "string",
+            "required": true,
+            "in": "path",
+            "format": "uuid"
+          },
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./definitions.json#/parameters/clientRequestId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single software update configuration Run.",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationRun"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "A single software update configuration Run.",
-              "schema": {
-                "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationRun"
-              }
-            },
-            "404": {
-              "description": "Resource group, account, or software update configuration doesn't exist."
-            }
+          },
+          "404": {
+            "description": "Resource group, account, or software update configuration doesn't exist."
           }
         }
-      },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationRuns": {
-        "get": {
-          "tags": [ "Software Update Configuration Run" ],
-          "description": "Return list of software update configuration runs",
-          "externalDocs": {
-            "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationRuns": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Run"
+        ],
+        "description": "Return list of software update configuration runs",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "List software update configuration machine runs": {
+            "$ref": "./examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json"
           },
-          "x-ms-examples": {
-            "List software update configuration machine runs": { "$ref": "./examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json" },
-            "List software update configuration machine run with status equal to 'Failed'": { "$ref": "./examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json" }
+          "List software update configuration machine run with status equal to 'Failed'": {
+            "$ref": "./examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurationRuns_List",
+        "parameters": [
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
           },
-          "operationId": "SoftwareUpdateConfigurationRuns_List",
-          "parameters": [
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
-            },
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
-            },
-            {
-              "$ref": "#/parameters/automationAccountName"
-            },
-            {
-              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
-            },
-            {
-              "$ref": "#/parameters/clientRequestId"
-            },
-            {
-              "name": "$filter",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
-            },
-            {
-              "name": "$skip",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "number of entries you skip before returning results"
-            },
-            {
-              "name": "$top",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "Maximum number of entries returned in the results collection"
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/automationAccountName"
+          },
+          {
+            "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/clientRequestId"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "number of entries you skip before returning results"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Maximum number of entries returned in the results collection"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return list of software update configurations runs.",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationRunListResult"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "Return list of software update configurations runs.",
-              "schema":{
-                "$ref": "./definitions.json#/definitions/softwareUpdateConfigurationRunListResult"
-              }
-            },
-            "404": {
-              "description": "Resource group, or account doesn't exist."
-            }
+          },
+          "404": {
+            "description": "Resource group, or account doesn't exist."
           }
         }
       }
     }
   }
-  
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
@@ -53,10 +53,10 @@
           "operationId": "SoftwareUpdateConfigurationRuns_GetById",
           "parameters": [
             {
-              "$ref": "./definitions.json#/parameters/subscriptionId"
+              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
             },
             {
-              "$ref": "./definitions.json#/parameters/resourceGroupName"
+                "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
             },
             {
               "$ref": "./definitions.json#/parameters/automationAccountName"
@@ -70,7 +70,7 @@
               "format": "uuid"
             },
             {
-              "$ref": "./definitions.json#/parameters/apiVersion"
+              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
             },
             {
               "$ref": "./definitions.json#/parameters/clientRequestId"

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
@@ -103,16 +103,16 @@
           "operationId": "SoftwareUpdateConfigurationRuns_List",
           "parameters": [
             {
-              "$ref": "#/parameters/subscriptionId"
+              "$ref": "../2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
             },
             {
-              "$ref": "#/parameters/resourceGroupName"
+              "$ref": "../2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
             },
             {
               "$ref": "#/parameters/automationAccountName"
             },
             {
-              "$ref": "#/parameters/apiVersion"
+              "$ref": "../2015-10-31/definitions.json#/parameters/ApiVersionParameter"
             },
             {
               "$ref": "#/parameters/clientRequestId"

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
@@ -118,6 +118,13 @@
               "$ref": "#/parameters/clientRequestId"
             },
             {
+              "name": "$filter",
+              "in": "query",
+              "required": false,
+              "type": "string",
+              "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+            },
+            {
               "name": "$skip",
               "in": "query",
               "required": false,
@@ -130,13 +137,6 @@
               "required": false,
               "type": "string",
               "description": "Maximum number of entries returned in the results collection"
-            },
-            {
-              "name": "$filter",
-              "in": "query",
-              "required": false,
-              "type": "string",
-              "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
             }
           ],
           "responses": {

--- a/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/2017-05-15-preview/softwareUpdateConfigurationRun.json
@@ -50,7 +50,7 @@
           "x-ms-examples": {
             "Get software update configuration runs by Id": { "$ref": "./examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json" }
           },
-          "operationId": "softwareUpdateConfigurationRuns_GetById",
+          "operationId": "SoftwareUpdateConfigurationRuns_GetById",
           "parameters": [
             {
               "$ref": "./definitions.json#/parameters/subscriptionId"
@@ -62,7 +62,12 @@
               "$ref": "./definitions.json#/parameters/automationAccountName"
             },
             {
-              "$ref": "./definitions.json#/parameters/softwareUpdateConfigurationRunId"
+              "name": "softwareUpdateConfigurationRunId",
+              "description": "The Id of the software update configuration run.",
+              "type": "string",
+              "required": true,
+              "in": "path",
+              "format": "uuid"
             },
             {
               "$ref": "./definitions.json#/parameters/apiVersion"
@@ -95,7 +100,7 @@
             "List software update configuration machine runs": { "$ref": "./examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json" },
             "List software update configuration machine run with status equal to 'Failed'": { "$ref": "./examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json" }
           },
-          "operationId": "softwareUpdateConfigurationRuns_List",
+          "operationId": "SoftwareUpdateConfigurationRuns_List",
           "parameters": [
             {
               "$ref": "#/parameters/subscriptionId"


### PR DESCRIPTION
- Better name for resource operations
- First letter capital for better looking doc
- Cleaned common definition file
- Modeled bitfield enums as comma separated strings as it seems swagger only support single value enum!
- Replaced URL parameter reference with the actual parameter definition as it was not added to constructors in code generation
- Removed discriminator property from operatingSystem as it prevented a property from being added to generated model
- fixed x-ms-enum without enum on same level error in code generation, was always there but for some reason CG was ok!
- Made resourceGroupName global parameter a client property, to avoid passing it to all sdk methods
- Removed subid/rg/apiversion and referenced one on previous version definitions
- Added missing automationAccountName parameter
- Made resourceGroupName passed in function for account resource
- Made schedule info required property
- Some changes were done to see how they impact code generation, but ended up as no op. Ignored here.